### PR TITLE
Middleware based identity resolver

### DIFF
--- a/src/Bouncer.php
+++ b/src/Bouncer.php
@@ -12,7 +12,7 @@ class Bouncer implements BouncerInterface
 
     protected $identity;
 
-    protected static $identityResolver;
+    protected $identityResolver;
 
     protected $policies = [];
 
@@ -23,7 +23,7 @@ class Bouncer implements BouncerInterface
     public function __construct(callable $identityResolver = null, array $policies = [])
     {
         $this->policies = $policies;
-        static::$identityResolver = $identityResolver;
+        $this->identityResolver = $identityResolver;
     }
 
     public function addAfterCallback(callable $callback)
@@ -192,9 +192,11 @@ class Bouncer implements BouncerInterface
      * @param callable
      * @return void
      */
-    public static function setIdentityResolver(callable $resolver)
+    public function setIdentityResolver(callable $resolver)
     {
-        static::$identityResolver = $resolver;
+        $this->identityResolver = $resolver;
+
+        return $this;
     }
 
     /**
@@ -204,7 +206,7 @@ class Bouncer implements BouncerInterface
      */
     public function resolveIdentity()
     {
-        $callable = static::$identityResolver;
+        $callable = $this->identityResolver;
 
         return $callable();
     }

--- a/src/BouncerInterface.php
+++ b/src/BouncerInterface.php
@@ -7,5 +7,5 @@ interface BouncerInterface
 
     public function denies($ability, array $arguments = []);
 
-    public static function setIdentityResolver(callable $resolver);
+    public function setIdentityResolver(callable $resolver);
 }

--- a/src/Middleware/AuthorizationMiddleware.php
+++ b/src/Middleware/AuthorizationMiddleware.php
@@ -40,19 +40,10 @@ class AuthorizationMiddleware
      */
     public function __invoke($request, $response, $next)
     {
-        $response = $next($request, $response);
         $bouncer = $this->bouncer;
 
         if (is_string($bouncer)) {
-            $bouncer = new $this->$bouncer();
-
-            if (!class_exists('Cake\Authorization\Identity')) {
-                trigger_error('The AuthorizationMiddleware requires that you are using the Cake\Authorization plugin.', E_WARNING);
-            }
-
-            $bouncer->setIdentityResolver(function () use ($request) {
-                return $request->getAttribute('identity');
-            });
+            $bouncer = new $bouncer();
         }
 
         if (!$bouncer instanceof BouncerInterface) {
@@ -61,6 +52,6 @@ class AuthorizationMiddleware
 
         $response = $response->withAttribute('authorization', $bouncer);
 
-        return $response;
+        return $next($request, $response);
     }
 }

--- a/src/Middleware/AuthorizationMiddleware.php
+++ b/src/Middleware/AuthorizationMiddleware.php
@@ -23,9 +23,9 @@ class AuthorizationMiddleware
     /**
      * Constructor
      *
-     * @param string|\Cake\Authorization\BouncerInterface|null
+     * @param string|\Cake\Authorization\BouncerInterface
      */
-    public function __construct($bouncer = null)
+    public function __construct($bouncer)
     {
         $this->bouncer = $bouncer;
     }

--- a/src/Middleware/IdentityResolverMiddleware.php
+++ b/src/Middleware/IdentityResolverMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+namespace Authorization\Middleware;
+
+use Authorization\BouncerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class IdentityResolverMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        /* @var $bouncer BouncerInterface */
+        $bouncer = $request->getAttribute('authorization');
+
+        $bouncer->setIdentityResolver(function() use ($request) {
+            return $request->getAttribute('identity');
+        });
+
+        return $next($request, $response);
+    }
+}


### PR DESCRIPTION
I don't quite like that identity resolver is static. I think that a bouncer can be isolated completely using middleware.

This is my proposal for attaching identity resolver using middleware.

```php
class Application 
{
    public function middleware(MiddlewareQueue $middleware)
    {
        $bouncer = new MyConfiguredBouncer();
        $authorization = new AuthorizationMiddleware($bouncer);

        $middleware
            // set up authentication
            ->add($authorization)
            ->add(IdentityResolverMiddleware::class);

        return $middleware;
    }
}
```

I'll post more PRs with my suggestions as I explore the code :slightly_smiling_face: 